### PR TITLE
Remove optional P-Chain signing language

### DIFF
--- a/ACPs/77-reinventing-subnets/README.md
+++ b/ACPs/77-reinventing-subnets/README.md
@@ -44,8 +44,6 @@ At a high-level, L1s can manage their validator sets externally to the P-Chain b
 
 To enable management of an L1's validator set externally to the P-Chain, Warp message verification will be added to the [`PlatformVM`](https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm). For a Warp message to be considered valid by the P-Chain, at least 67% of the `sourceChainID`'s weight must have participated in the aggregate BLS signature. This is equivalent to the threshold set for the C-Chain. A future ACP may be proposed to support modification of this threshold on a per-L1 basis.
 
-For messages produced by the P-Chain for a given L1, only that L1's validators must be willing to provide signatures, rather than the entire Primary Network validator set. This optimization is possible because all validators will still sync the P-Chain.
-
 The following Warp message payloads are introduced on the P-Chain:
 
 - `SubnetToL1ConversionMessage`


### PR DESCRIPTION
The possible optimization is that chains verifying a message from the P-Chain may choose to do so using its own validator set, since all of its validator still sync the P-Chain. However, this is up to the receiving chain to define for itself, so it is outside the scope of ACP-77.

All primary network validators must still be willing to sign messages produced by the P-Chain because the messages don't have an explicit destination chain, and may be consumed by the C-Chain. 

Theoretically L1-only validators do not need to be willing to sign messages from the P-Chain that are regarding the validator set of L1s that they do not track, but this is completely optional and also not needed for the specification of the ACP.